### PR TITLE
Update vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "dependencies": [
     "glm",
-    "sdl2"
+    "sdl2",
+    "glew"
   ]
 }


### PR DESCRIPTION
Adding glew to vcpkg dependencies fixes the compilation chain.
`Could NOT find GLEW (missing: GLEW_INCLUDE_DIRS GLEW_LIBRARIES)`